### PR TITLE
Drop Year from Movie model

### DIFF
--- a/MovieApi/Migrations/20250709140000_RemoveYearColumn.Designer.cs
+++ b/MovieApi/Migrations/20250709140000_RemoveYearColumn.Designer.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MovieApi.Models;
 
@@ -10,9 +11,11 @@ using MovieApi.Models;
 namespace MovieApi.Migrations
 {
     [DbContext(typeof(MovieContext))]
-    partial class MovieContextModelSnapshot : ModelSnapshot
+    [Migration("20250709140000_RemoveYearColumn")]
+    partial class RemoveYearColumn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MovieApi/Migrations/20250709140000_RemoveYearColumn.cs
+++ b/MovieApi/Migrations/20250709140000_RemoveYearColumn.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MovieApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveYearColumn : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Year",
+                table: "Movies");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Year",
+                table: "Movies",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+    }
+}

--- a/MovieApi/Models/Movie.cs
+++ b/MovieApi/Models/Movie.cs
@@ -7,7 +7,6 @@ namespace MovieApi.Models
         public int Id { get; set; }
         public string Title { get; set; } = null!;
         public int ReleaseYear { get; set; }
-        public int Year { get; set; }
         public string Genre { get; set; } = null!;
         public int Duration { get; set; }
 


### PR DESCRIPTION
## Summary
- remove obsolete `Year` property from `Movie`
- add EF Core migration to drop `Year` column

## Testing
- `dotnet ef migrations list --project MovieApi/MovieApi.csproj --startup-project MovieApi/MovieApi.csproj` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e7665f3b48329bece32178310676c